### PR TITLE
Introduce aws codeartifact login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This project produces a docker image based on amazon/aws-cli with added functionality
 to support automatic role switching with STS, etc.
 
-This repository produces both linyx/amd64 and linux/arm64 docker images. 
+This repository produces both linux/amd64 and linux/arm64 docker images.
 
 # How do I use this docker image?
 
@@ -43,24 +43,40 @@ docker run -it --rm \
   truemark/aws-cli:latest
 ```
 
+Example using codeartifact support (OIDC + CODEARTIFACT)
+```bash
+docker run -it --rm \
+  -e AWS_OIDC_ROLE_ARN="YOUR_ACCESS_KEY_ID" \
+  -e AWS_WEB_IDENTITY_TOKEN="YOUR_OIDC_TOKEN" \
+  -e AWS_ASSUME_ROLE_ARN="YOUR_ROLE_ARN" \
+  -e AWS_ROLE_SESSION_NAME="YOUR_SESSION_NAME" \
+  -e AWS_CODEARTIFACT_TOOL="YOUR_CODEARTIFACT_TOOL" \
+  -e AWS_CODEARTIFACT_DOMAIN="YOUR_CODEARTIFACT_DOMAIN" \
+  -e AWS_CODEARTIFACT_REPO="YOUR_CODEARTIFACT_REPO" \
+  truemark/aws-cli:latest
+```
+
 # What are all the environment variables supported by this image?
 
 | Environment Variable        | Description                                                                             |
 |:----------------------------|:----------------------------------------------------------------------------------------|
- | AWS_ACCESS_KEY_ID           | Optional access key if using default AWS authentication.                                |
- | AWS_SECRET_ACCESS_KEY       | Optional secret access key if using default AWS authentication.                         |
+| AWS_ACCESS_KEY_ID           | Optional access key if using default AWS authentication.                                |
+| AWS_ASSUME_ROLE_ARN         | Optional role to assume.                                                                |
+| AWS_CODEARTIFACT_DOMAIN     | AWS Codeartifact domain                                                                 |
+| AWS_CODEARTIFACT_REPO       | AWS Codeartifact repository                                                             |
+| AWS_CODEARTIFACT_TOOL       | AWS Codeartifact tool type (nuget, npm, maven, pip, etc)                                |
+| AWS_EXCLUDE_ACCOUNT_IDS     | Account IDs to exclude when using aws_organization_account_ids function.                |
+| AWS_EXCLUDE_OU_IDS          | AWS Organizational units to exclude when using aws_organization_account_ids.            |
+| AWS_OIDC_ROLE_ARN           | Alternative variable to AWS_ROLE_ARN.                                                   |
+| AWS_ROLE_ARN                | Optional role to assume if using AWS OIDC authentication.                               |
+| AWS_ROLE_SESSION_NAME       | Optional session name used in audit logs used when assuming a role.                     |
+| AWS_SECRET_ACCESS_KEY       | Optional secret access key if using default AWS authentication.                         |
 | AWS_SESSION_TOKEN           | Optional session token used with temporary credentials.                                 |
 | AWS_WEB_IDENTITY_TOKEN      | Optional OIDC token if using AWS OIDC authentication.                                   |
- | AWS_WEB_IDENTITY_TOKEN_FILE | Optional token file if using AWS OIDC authentication.                                   |
- | AWS_ROLE_ARN                | Optional role to assume if using AWS OIDC authentication.                               |
- | AWS_OIDC_ROLE_ARN           | Alternative variable to AWS_ROLE_ARN.                                                   |
- | AWS_ROLE_SESSION_NAME       | Optional session name used in audit logs used when assuming a role.                     |
- | AWS_ASSUME_ROLE_ARN         | Optional role to assume.                                                                |
- | AWS_EXCLUDE_ACCOUNT_IDS     | Account IDs to exclude when using aws_organization_account_ids function.                |
- | AWS_EXCLUDE_OU_IDS          | AWS Organizational units to exclude when using aws_organization_account_ids.            |
- | GIT_CRYPT_KEY               | Optional base64 encoded git-crypt key used to unlock the git repository with git-crypt. |
- | GIT_CRYPT_KEY_FILE          | Optional git-crypt key file used to unlock the git repository with git-crypt.           |           
- | LOCAL_PATH                  | Optional value to change working directories.                                           |
+| AWS_WEB_IDENTITY_TOKEN_FILE | Optional token file if using AWS OIDC authentication.                                   |
+| GIT_CRYPT_KEY               | Optional base64 encoded git-crypt key used to unlock the git repository with git-crypt. |
+| GIT_CRYPT_KEY_FILE          | Optional git-crypt key file used to unlock the git repository with git-crypt.           |
+| LOCAL_PATH                  | Optional value to change working directories.                                           |
 
 ## Maintainers
 

--- a/helper.sh
+++ b/helper.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # Prints arguments if DEBUG environment variable is set to true
 function debug() {
   if [[ -n "${DEBUG+x}" ]] && [[ "${DEBUG}" == "true" ]]; then

--- a/helper.sh
+++ b/helper.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Prints arguments if DEBUG environment variable is set to true
 function debug() {
   if [[ -n "${DEBUG+x}" ]] && [[ "${DEBUG}" == "true" ]]; then
@@ -254,6 +256,51 @@ function if_local_path() {
   fi
 }
 
+# Login to codeartifact domain/repo using $TOOL (npm, nuget, etc)
+function codeartifact_login() {
+  debug "Calling codeartifact_login()"
+  aws codeartifact login --tool "${AWS_CODEARTIFACT_TOOL}" \
+    --repository "${AWS_CODEARTIFACT_REPO}" \
+    --domain "${AWS_CODEARTIFACT_DOMAIN}" \
+    --region "${AWS_DEFAULT_REGION}" || debug "aws codeartifact login failed."
+    debug "aws codeartifact login successful."
+}
+
+# Calls codeartifact_login if AWS_CODEARTIFACT_{DOMAIN,REPO,TOOL} are set
+function if_codeartifact_login() {
+  debug "Calling if_codeartifact_login()"
+  if [[ -n "${AWS_CODEARTIFACT_TOOL+x}" ]] && [[ -n "${AWS_CODEARTIFACT_REPO+x}" ]] && [[ -n "${AWS_CODEARTIFACT_DOMAIN+x}" ]] ; then
+    case "${AWS_CODEARTIFACT_TOOL}" in
+    npm|mvn|gradle|pip|twine|nuget)
+      continue
+        ;;
+    *)
+      debug "Unrecognized codeartifact tool type."
+      debug "Supported types: npm, mvn, gradle, pip, twine, nuget"
+      exit 1
+    esac
+    debug "Detected tool: ${AWS_CODEARTIFACT_TOOL}"
+    debug "Detected repo: ${AWS_CODEARTIFACT_REPO}"
+    debug "Detected domain: ${AWS_CODEARTIFACT_DOMAIN}"
+    debug "Detected account: ${AWS_ACCOUNT_ID}"
+    debug "Detected region: ${AWS_DEFAULT_REGION}"
+
+    if [[ "${AWS_CODEARTIFACT_TOOL+x}" == "nuget" ]]; then
+      debug "NuGet login detected. Requesting auth token."
+      echo CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${AWS_CODEARTIFACT_DOMAIN} \
+        --domain-owner ${AWS_ACCOUNT_ID} \
+        --region ${AWS_DEFAULT_REGION} \
+        --query authorizationToken --output text) > codeartifact_token
+
+      debug "CODEARTIFACT_AUTH_TOKEN saved to file: codeartifact_token"
+    else
+      codeartifact_login
+    fi
+  else
+    debug "Codeartifact variables not detected"
+  fi
+}
+
 function initialize() {
   set -euo pipefail
   source /helper.sh
@@ -263,4 +310,5 @@ function initialize() {
   if_aws_account_id
   if_git_crypt_unlock
   if_local_path
+  if_codeartifact_login
 }


### PR DESCRIPTION
This patch introduces logic for aws codeartifact login by adding two functions to `helper.sh`. Updates were also made to the `README.md` describing usage and three new environment variables.

`AWS_CODEARTIFACT_REPO`
`AWS_CODEARTIFACT_DOMAIN`
`AWS_CODEARTIFACT_TOOL`

Fixed typo. Sorted variable list.