### PR TITLE
minor fix; can't use continue in this context

### DIFF
--- a/helper.sh
+++ b/helper.sh
@@ -270,7 +270,7 @@ function if_codeartifact_login() {
   if [[ -n "${AWS_CODEARTIFACT_TOOL+x}" ]] && [[ -n "${AWS_CODEARTIFACT_REPO+x}" ]] && [[ -n "${AWS_CODEARTIFACT_DOMAIN+x}" ]] ; then
     case "${AWS_CODEARTIFACT_TOOL}" in
     npm|mvn|gradle|pip|twine|nuget)
-      continue
+      debug "Recognized codeartifact tool type."
         ;;
     *)
       debug "Unrecognized codeartifact tool type."


### PR DESCRIPTION
Didn't catch this initially but in further debugging I experienced this error:

```
bash: continue: only meaningful in a `for', `while', or `until' loop
```

Replacing `continue` keyword with simple debug output confirmation.